### PR TITLE
Fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,44 @@
 <html>
     <head>
         <title>MassPass</title>
-    
-        <script src="https://carrotcypher.github.io/password-reset-urls/password-reset-urls.js"></script>
+
         <script>
-            
+            let password_reset_urls = {};
+
+            !async function () {
+                try {
+                    const response = await fetch("https://raw.githubusercontent.com/apple/password-manager-resources/main/quirks/change-password-URLs.json");
+                    password_reset_urls = await response.json();
+                } catch {
+                    password_reset_urls = {};
+                }
+            }();
+        </script>
+
+        <script>
+            function isIP(address) {
+                const parts = address.split('.');
+
+                if (parts.length !== 4) {
+                    return false;
+                }
+
+                for (let i = 0; i < parts.length; i++) {
+                    const part = parts[i];
+
+                    if (!/^\d+$/.test(part)) {
+                    return false;
+                    }
+
+                    const num = parseInt(part, 10);
+                    if (num < 0 || num > 255) {
+                    return false;
+                    }
+                }
+
+                return true;
+            }
+
             function isJson(str) {
                 try {
                     JSON.parse(str);
@@ -13,118 +47,90 @@
                     return false;
                 }
                 return true;
-            }        
-
-            
-            // Taken from https://codepen.io/martinkrulltott/pen/GWWWQj
-            function extractDomain(url) {
-              var domain;
-              //find & remove protocol (http, ftp, etc.) and get domain
-              if (url.indexOf("://") > -1) {
-                domain = url.split('/')[2];
-              }
-              else {
-                domain = url.split('/')[0];
-              }
-
-              //find & remove www
-              if (domain.indexOf("www.") > -1) { 
-                domain = domain.split('www.')[1];
-              }
-
-              domain = domain.split(':')[0]; //find & remove port number
-              domain = domain.split('?')[0]; //find & remove url params
-
-              return domain;
             }
 
-            
+            // Taken from https://codepen.io/martinkrulltott/pen/GWWWQj
+            function extractDomain(url) {
+                let domain;
+                //find & remove protocol (http, ftp, etc.) and get domain
+                if (url.indexOf("://") > -1) {
+                    domain = url.split('/')[2];
+                }
+                else {
+                    domain = url.split('/')[0];
+                }
+
+                //find & remove www
+                if (domain.indexOf("www.") > -1) {
+                    domain = domain.split('www.')[1];
+                }
+
+                domain = domain.split(':')[0]; //find & remove port number
+                domain = domain.split('?')[0]; //find & remove url params
+
+                return domain;
+            }
+
             function load_pass(passwd_json_list) {
                 if (!isJson(passwd_json_list)) {
                     alert("This is invalid JSON");
                 } else {
-                    passwd_json_list = JSON.parse(passwd_json_list)
+                    passwd_json_list = JSON.parse(passwd_json_list);
+                    website_list.value = "";
+                    list_of_sites = [];
 
-                    website_list.value=""
-                    
-                    list_of_sites = []
-                    
-                    for(var key in passwd_json_list["items"]) {
-                        if (passwd_json_list["items"][key]["login"]["uris"]) {
-                            if (passwd_json_list["items"][key]["login"]["uris"][0]) {
-                                if (passwd_json_list["items"][key]["login"]["uris"][0]["uri"]) {
-                                    website = passwd_json_list["items"][key]["login"]["uris"][0]["uri"];
-                                    
-                                    list_of_sites.push(extractDomain(website));
-                                }
-                            }
+                    for (const key in passwd_json_list["items"]) {
+                        if (passwd_json_list["items"]?.[key]?.["login"]?.["uris"]?.[0]?.["uri"]) {
+
+                            website = passwd_json_list["items"][key]["login"]["uris"][0]["uri"];
+                            list_of_sites.push(extractDomain(website));
                         }
                     }
-                    for(var key2 in list_of_sites) {
-                        website_list.value=website_list.value+list_of_sites[key2]+"\n"
+
+                    for (const key in list_of_sites) {
+                        website_list.value = website_list.value + list_of_sites[key] + "\n";
                     }
-                
-                    
                 }
             }
-
 
             function find_password_change_page(url) {
-
-                
                 if (password_reset_urls[url]) {
-                    return password_reset_urls[url]
+                    return password_reset_urls[url];
+                } else if (url.split(".").length > 1 && !isIP(url) && password_reset_urls[url.substring(url.indexOf(".") + 1)]) {
+                    return password_reset_urls[url.substring(url.indexOf(".") + 1)];
                 } else {
-                    return url;
-
+                    return "https://" + url;
                 }
             }
-            
-            
-            function start_changing(website_url_list) {
 
+            function start_changing(website_url_list) {
                 list_of_sites = website_url_list.split("\n");
 
-                
-                /// List all domains
-
-                /***
-
-                for (var key3 in list_of_sites) {
-                    if (list_of_sites[key3]) {
-                        
-                    }
-                    console.log(list_of_sites[key3])
-                }
-
-                ***/
-                
                 current_site.innerHTML = list_of_sites[0]
-                window.open("https://" + find_password_change_page(list_of_sites[0]), '_blank');
-                list_of_sites.shift()
-                website_list.value=""
-                for(var key2 in list_of_sites) {
-                    website_list.value=website_list.value+list_of_sites[key2]+"\n"
-                }
-                
-                
+                window.open(find_password_change_page(list_of_sites[0]), '_blank');
+                list_of_sites.shift();
+                website_list.value = "";
 
+                for (const key in list_of_sites) {
+                    website_list.value = website_list.value + list_of_sites[key] + "\n";
+                }
             }
 
             function init_script() {
-                const website_list = document.getElementById("website_list")
-                const current_site = document.getElementById("current_site")
-                website_list.value = ""
-                current_site.innerHTML = ""
+                const website_list = document.getElementById("website_list");
+                const current_site = document.getElementById("current_site");
+                website_list.value = "";
+                current_site.innerHTML = "";
             }
         </script>
     </head>
+
     <body>
         <div style="display:block; padding:50px">
             <h2>MassPass</h2>
             <p>MassPass is a website mass-password reset helper. <a href="https://github.com/carrotcypher/masspass/">Check the code on Github here.</a></p>
-        </div>        
-        
+        </div>
+
         <div style="display:inline-block; padding:50px; width:250px">
             <h2>Load</h2>
             <p>
@@ -133,26 +139,22 @@
                 here and press the "Load" button<br></p>
             <textarea name="passwd_json_list" id="passwd_json_list" rows="10" cols="30"></textarea><br><br>
             <input type=button value="Load" onClick="load_pass(document.getElementById('passwd_json_list').value)">
-                
         </div>
-        
+
         <div style="display:inline-block; padding:50px; width:250px">
             <h2>Domains</h2>
             <p>
                 This lists all domains from the imported file. Click Start to begin the process.<br></p>
             <textarea name="website_list" id="website_list" disabled=true rows="10" cols="30"></textarea><br><br>
             <input type=button value="Start" onClick="start_changing(document.getElementById('website_list').value)">
-                
         </div>
-        
+
         <div style="display:inline-block; padding:50px; width:250px">
             <h2>Current</h2>
             <div style="border:1px black solid; height:150px; width:200px; padding:20px" name="current_site" id="current_site"></div><br>
             <input type=button value="Next" onClick="start_changing(document.getElementById('website_list').value)">
-                
         </div>
-        
+
         <script>init_script()</script>
     </body>
-
 </html>


### PR DESCRIPTION
- Changed password reset URLs to the more maintained [apple/password-manager-resources](https://github.com/apple/password-manager-resources/blob/main/quirks/change-password-URLs.json)
- Changed [vars to const/let](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Variables#a_note_about_var)
- Fixed a bug where the script crashes if the Bitwarden export has other types of vault elements than a login (e.g. note, card, etc)
- Used optional chaining while checking for any logins to avoid repetitive conditions and further bugs if Bitwarden introduces more types
- Added basic IP check so a domain can be matched with and without subdomains (used to only strictly match with subdomain)
- Minor syntax corrections

Feel free to edit for any further changes.