### PR TITLE
ignore some bad URLs from the parsing of export

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,12 +78,17 @@
                     passwd_json_list = JSON.parse(passwd_json_list);
                     website_list.value = "";
                     list_of_sites = [];
+                     // Define a set of invalid website values
+                    const invalidWebsites = new Set(["http://","https://", "www.", "", "none", "http://none", "file:/*"]);
+
 
                     for (const key in passwd_json_list["items"]) {
                         if (passwd_json_list["items"]?.[key]?.["login"]?.["uris"]?.[0]?.["uri"]) {
-
                             website = passwd_json_list["items"][key]["login"]["uris"][0]["uri"];
-                            list_of_sites.push(extractDomain(website));
+                            // Check if website is not null or empty or no FQD
+                            if (website && !invalidWebsites.has(website)) {
+                                list_of_sites.push(extractDomain(website));
+                            }
                         }
                     }
 


### PR DESCRIPTION
Using a large bitwarden vault that came from lastpass, there are several bad entries of URLs.  To speed up the changing of only valid URLs, a small change was made to check to see if the URL is not 'bad'.   

Arguably, instead of a 'deny list' this code could validate the URI is a valid format.  I did not do that so not to introduce a JS dependency in the code. 